### PR TITLE
Add modular meeting summarizer pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "meeting_summerizer.main"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# meeting_summerizer
-Python Base App to Summerize BigBlueButton meetings using Whisper and LLM Selfhosted
+# Meeting Summarizer
+
+This project provides a modular pipeline to capture audio from BigBlueButton sessions,
+transcribe it using a dummy ASR, store transcripts, chunk them, and produce simple summaries.
+The pipeline is orchestrated with Prefect.
+
+## Requirements
+
+- Python 3.12+
+- Docker (for running via `docker-compose`)
+
+## Usage
+
+### Local
+
+```bash
+pip install -r requirements.txt
+python -m meeting_summerizer.main
+```
+
+### Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+The application will log generated summaries.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: transcripts
+    ports:
+      - "5432:5432"
+  app:
+    build: .
+    environment:
+      DB_URL: postgresql+psycopg2://user:pass@db:5432/transcripts
+    depends_on:
+      - db
+    command: ["python", "-m", "meeting_summerizer.main"]

--- a/meeting_summerizer/agents/capture.py
+++ b/meeting_summerizer/agents/capture.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Generator
+
+logger = logging.getLogger(__name__)
+
+
+defensive_log = logger.debug
+
+
+@dataclass
+class CaptureConfig:
+    meeting_id: str
+    frame_count: int = 5
+
+
+class CaptureAgent:
+    """Simulates capturing audio frames from BigBlueButton."""
+
+    def __init__(self, config: CaptureConfig) -> None:
+        self.config = config
+        defensive_log("CaptureAgent initialized with %s", self.config)
+
+    def run(self) -> Generator[bytes, None, None]:
+        """Yield dummy audio frames."""
+        for i in range(self.config.frame_count):
+            defensive_log("Capturing frame %d", i)
+            yield f"audio_frame_{i}".encode()
+        defensive_log("Capture complete")

--- a/meeting_summerizer/agents/chunking.py
+++ b/meeting_summerizer/agents/chunking.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Generator
+
+logger = logging.getLogger(__name__)
+
+defensive_log = logger.debug
+
+
+@dataclass
+class ChunkingConfig:
+    size: int = 3
+
+
+class ChunkingAgent:
+    """Chunks transcripts into fixed-size batches."""
+
+    def __init__(self, config: ChunkingConfig) -> None:
+        self.config = config
+        defensive_log("ChunkingAgent initialized with %s", self.config)
+
+    def run(self, transcripts: Iterable[str]) -> Generator[list[str], None, None]:
+        chunk: list[str] = []
+        for text in transcripts:
+            chunk.append(text)
+            if len(chunk) >= self.config.size:
+                defensive_log("Yielding chunk: %s", chunk)
+                yield chunk
+                chunk = []
+        if chunk:
+            defensive_log("Yielding final chunk: %s", chunk)
+            yield chunk
+        defensive_log("Chunking complete")

--- a/meeting_summerizer/agents/orchestrator.py
+++ b/meeting_summerizer/agents/orchestrator.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from prefect import flow, task
+
+from meeting_summerizer.agents.capture import CaptureAgent, CaptureConfig
+from meeting_summerizer.agents.transcription import TranscriptionAgent, TranscriptionConfig
+from meeting_summerizer.agents.storage import StorageAgent, StorageConfig
+from meeting_summerizer.agents.chunking import ChunkingAgent, ChunkingConfig
+from meeting_summerizer.agents.summarization import SummarizationAgent, SummarizationConfig
+from meeting_summerizer.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+defensive_log = logger.debug
+
+
+@task
+def capture_task(cfg: CaptureConfig):
+    agent = CaptureAgent(cfg)
+    return list(agent.run())
+
+
+@task
+def transcription_task(cfg: TranscriptionConfig, frames: list[bytes]):
+    agent = TranscriptionAgent(cfg)
+    return list(agent.run(frames))
+
+
+@task
+def storage_task(cfg: StorageConfig, transcripts: list[str]):
+    defensive_log("Using DB url: %s", cfg.db_url)
+    agent = StorageAgent(cfg)
+    agent.run(transcripts)
+    return agent.fetch_all()
+
+
+@task
+def chunking_task(cfg: ChunkingConfig, transcripts: list[str]):
+    agent = ChunkingAgent(cfg)
+    return list(agent.run(transcripts))
+
+
+@task
+def summarization_task(cfg: SummarizationConfig, chunks: list[list[str]]):
+    agent = SummarizationAgent(cfg)
+    return agent.run(chunks)
+
+
+@flow
+def orchestrator():
+    settings = get_settings()
+    defensive_log("Starting flow with settings %s", settings)
+    frames = capture_task(CaptureConfig(meeting_id=settings.meeting_id))
+    transcripts = transcription_task(TranscriptionConfig(), frames)
+    stored = storage_task(StorageConfig(db_url=settings.db_url), transcripts)
+    chunks = chunking_task(ChunkingConfig(), stored)
+    summaries = summarization_task(SummarizationConfig(), chunks)
+    for summary in summaries:
+        logger.info("Summary: %s", summary)
+
+
+if __name__ == "__main__":
+    orchestrator()

--- a/meeting_summerizer/agents/storage.py
+++ b/meeting_summerizer/agents/storage.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+defensive_log = logger.debug
+
+Base = declarative_base()
+
+
+class Transcript(Base):
+    __tablename__ = "transcripts"
+
+    id = Column(Integer, primary_key=True)
+    text = Column(String, nullable=False)
+
+
+@dataclass
+class StorageConfig:
+    db_url: str = "sqlite:///data.db"
+
+
+class StorageAgent:
+    """Stores transcripts in a database."""
+
+    def __init__(self, config: StorageConfig) -> None:
+        self.config = config
+        self.engine = create_engine(self.config.db_url)
+        Base.metadata.create_all(self.engine)
+        defensive_log("StorageAgent initialized with %s", self.config)
+
+    def run(self, transcripts: Iterable[str]) -> None:
+        with Session(self.engine) as session:
+            for text in transcripts:
+                defensive_log("Storing transcript: %s", text)
+                session.add(Transcript(text=text))
+            session.commit()
+        defensive_log("Storage complete")
+        # dispose connection to ensure SQLite writes to disk
+        self.engine.dispose()
+
+    def fetch_all(self) -> list[str]:
+        with Session(self.engine) as session:
+            rows = session.query(Transcript).all()
+            return [row.text for row in rows]

--- a/meeting_summerizer/agents/summarization.py
+++ b/meeting_summerizer/agents/summarization.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, List
+
+logger = logging.getLogger(__name__)
+
+defensive_log = logger.debug
+
+
+@dataclass
+class SummarizationConfig:
+    sentence_count: int = 2
+
+
+class SummarizationAgent:
+    """Produces a naive summary from transcript chunks."""
+
+    def __init__(self, config: SummarizationConfig) -> None:
+        self.config = config
+        defensive_log("SummarizationAgent initialized with %s", self.config)
+
+    def run(self, chunks: Iterable[List[str]]) -> List[str]:
+        summaries: List[str] = []
+        for chunk in chunks:
+            text = " ".join(chunk)
+            defensive_log("Summarizing chunk: %s", text)
+            sentences = [s.strip() for s in text.split(".") if s.strip()]
+            summary = ". ".join(sentences[: self.config.sentence_count])
+            if summary and not summary.endswith('.'):
+                summary += '.'
+            summaries.append(summary)
+        defensive_log("Summarization complete")
+        return summaries

--- a/meeting_summerizer/agents/transcription.py
+++ b/meeting_summerizer/agents/transcription.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Generator, Iterable
+
+logger = logging.getLogger(__name__)
+
+defensive_log = logger.debug
+
+
+@dataclass
+class TranscriptionConfig:
+    language: str = "en"
+
+
+class TranscriptionAgent:
+    """Dummy transcription converting audio frames to text."""
+
+    def __init__(self, config: TranscriptionConfig) -> None:
+        self.config = config
+        defensive_log("TranscriptionAgent initialized with %s", self.config)
+
+    def run(self, frames: Iterable[bytes]) -> Generator[str, None, None]:
+        for i, frame in enumerate(frames):
+            defensive_log("Transcribing frame %d: %s", i, frame)
+            yield f"transcript {i} for {self.config.language}"
+        defensive_log("Transcription complete")

--- a/meeting_summerizer/config.py
+++ b/meeting_summerizer/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    db_url: str
+    meeting_id: str
+
+
+def get_settings() -> Settings:
+    return Settings(
+        db_url=os.getenv("DB_URL", "sqlite:///data.db"),
+        meeting_id=os.getenv("MEETING_ID", "demo-meeting"),
+    )

--- a/meeting_summerizer/main.py
+++ b/meeting_summerizer/main.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from meeting_summerizer.agents.orchestrator import orchestrator
+
+
+if __name__ == "__main__":
+    orchestrator()

--- a/meeting_summerizer/tests/test_capture.py
+++ b/meeting_summerizer/tests/test_capture.py
@@ -1,0 +1,7 @@
+from meeting_summerizer.agents.capture import CaptureAgent, CaptureConfig
+
+
+def test_capture():
+    agent = CaptureAgent(CaptureConfig(meeting_id="id", frame_count=2))
+    frames = list(agent.run())
+    assert len(frames) == 2

--- a/meeting_summerizer/tests/test_chunking.py
+++ b/meeting_summerizer/tests/test_chunking.py
@@ -1,0 +1,7 @@
+from meeting_summerizer.agents.chunking import ChunkingAgent, ChunkingConfig
+
+
+def test_chunking():
+    agent = ChunkingAgent(ChunkingConfig(size=2))
+    chunks = list(agent.run(["a", "b", "c"]))
+    assert chunks == [["a", "b"], ["c"]]

--- a/meeting_summerizer/tests/test_orchestrator.py
+++ b/meeting_summerizer/tests/test_orchestrator.py
@@ -1,0 +1,12 @@
+import os
+from meeting_summerizer.agents.orchestrator import orchestrator
+from meeting_summerizer.agents.storage import StorageAgent, StorageConfig
+
+
+def test_orchestrator(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_URL", f"sqlite:///{tmp_path}/flow.db")
+    monkeypatch.setenv("MEETING_ID", "test-meeting")
+    orchestrator()
+    agent = StorageAgent(StorageConfig(db_url=f"sqlite:///{tmp_path}/flow.db"))
+    rows = agent.fetch_all()
+    assert rows != []

--- a/meeting_summerizer/tests/test_storage.py
+++ b/meeting_summerizer/tests/test_storage.py
@@ -1,0 +1,11 @@
+import os
+
+from meeting_summerizer.agents.storage import StorageAgent, StorageConfig
+
+
+def test_storage(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    agent = StorageAgent(StorageConfig(db_url=db_url))
+    agent.run(["hello", "world"])
+    rows = agent.fetch_all()
+    assert rows == ["hello", "world"]

--- a/meeting_summerizer/tests/test_summarization.py
+++ b/meeting_summerizer/tests/test_summarization.py
@@ -1,0 +1,10 @@
+from meeting_summerizer.agents.summarization import (
+    SummarizationAgent,
+    SummarizationConfig,
+)
+
+
+def test_summarization():
+    agent = SummarizationAgent(SummarizationConfig(sentence_count=1))
+    summaries = agent.run([["hello world. this is a test."]])
+    assert summaries == ["hello world."]

--- a/meeting_summerizer/tests/test_transcription.py
+++ b/meeting_summerizer/tests/test_transcription.py
@@ -1,0 +1,10 @@
+from meeting_summerizer.agents.transcription import (
+    TranscriptionAgent,
+    TranscriptionConfig,
+)
+
+
+def test_transcription():
+    agent = TranscriptionAgent(TranscriptionConfig())
+    result = list(agent.run([b"a", b"b"]))
+    assert len(result) == 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "meeting_summerizer"
+version = "0.1.0"
+requires-python = ">=3.12"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+prefect
+SQLAlchemy
+psycopg2-binary
+nltk


### PR DESCRIPTION
## Summary
- implement pipeline agents for capture, transcription, storage, chunking, and summarization
- orchestrate with Prefect
- provide docker and docker-compose setup
- add tests for each agent and the orchestrator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d22b2d6c832ba1a289e412a6a3aa